### PR TITLE
Make AbstractWritableObj.addNormal non-final

### DIFF
--- a/Obj/src/main/java/de/javagl/obj/AbstractWritableObj.java
+++ b/Obj/src/main/java/de/javagl/obj/AbstractWritableObj.java
@@ -93,7 +93,7 @@ public class AbstractWritableObj implements WritableObj
     
 
     @Override
-    public final void addNormal(FloatTuple normal)
+    public void addNormal(FloatTuple normal)
     {
         // Empty default implementation
     }


### PR DESCRIPTION
The method should be implemented by derived classes. Thus, it should not be final.